### PR TITLE
Added build status icon to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CIPRS Reader
-
+[![Build Status](https://travis-ci.org/deardurham/ciprs-reader.svg?branch=master)](https://travis-ci.org/deardurham/ciprs-reader)
 
 ## Setup and Run:
 


### PR DESCRIPTION
Now that the travis builds are working, I've added an icon to show the build status of master.