### PR TITLE
Change offense date parser to return datetime, like offense datetime …

### DIFF
--- a/ciprs/parsers.py
+++ b/ciprs/parsers.py
@@ -270,6 +270,6 @@ class OffenseDate(Parser):
 
     def clean(self, matches):
         """Parse and convert the date to ISO 8601 format"""
-        date = dt.datetime.strptime(matches["value"], "%m/%d/%Y").date()
+        date = dt.datetime.strptime(matches["value"], "%m/%d/%Y")
         matches["value"] = date.isoformat()
         return matches

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -207,4 +207,4 @@ def test_offense_date():
     string = "    Offense Date: 11/28/2005   • Date: 04/13/2006"
     matches = parsers.OffenseDate().match(string)
     assert matches is not None, "Regex match failed"
-    assert matches["value"] == "2005-11-28"
+    assert matches["value"] == "2005-11-28T00:00:00"


### PR DESCRIPTION
500 error was happening because the most recent record compares dates by stripping the datetime, but it was chugging because some data in that field is represented as datetime, while others are represented as just dates, depending on which parser it came from. I prefer this change rather than modifying the most_recent_record function because I think it will make it easier to code in the future if we keep our data formats consistent.