### PR TITLE
Parse multiple records from a combined PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,55 +7,45 @@ Add pdf file to parse in /ignore folder then run:
 
 ```bash
 docker build -t ciprs-reader .
-docker run -v "${PWD}:/usr/src/app" ciprs-reader python ciprs_reader.py ignore/cypress-example.pdf
+docker run -v "${PWD}:/usr/src/app" ciprs-reader python ciprs-reader.py ignore/cypress-example.pdf
 ```
 
 Example output:
 
 ```json
-{
-    "General": {
-        "County": "DURHAM",
-        "File No": "00GR000000"
-    },
-    "Case Information": {
-        "Case Status": "DISPOSED",
-        "Offense Date": "2018-01-01T20:00:00"
-    },
-    "Defendant": {
-        "Date of Birth/Estimated Age": "1990-01-01",
-        "Name": "DOE,JON,BOJACK",
-        "Race": "WHITE",
-        "Sex": "MALE"
-    },
-    "Offense Record": {
-        "Records": [
+[
+    {
+        "General": {
+            "County": "DURHAM",
+            "File No": "00GR000000"
+        },
+        "Case Information": {
+            "Case Status": "DISPOSED",
+            "Offense Date": "2018-01-01T20:00:00"
+        },
+        "Defendant": {
+            "Date of Birth/Estimated Age": "1990-01-01",
+            "Name": "DOE,JON,BOJACK",
+            "Race": "WHITE",
+            "Sex": "MALE"
+        },
+        "District Court Offense Information": [
             {
-                "Action": "CHARGED",
-                "Description": "SPEEDING(80 mph in a 65 mph zone)",
-                "Severity": "INFRACTION",
-                "Law": "G.S. 20-141(B)",
-                "Code": "4450"
-            },
-            {
-                "Action": "ARRAIGNED",
-                "Description": "SPEEDING(80 mph in a 65 mph zone)",
-                "Severity": "INFRACTION",
-                "Law": "G.S. 20-141(B)",
-                "Code": "4450"
-            },
-            {
-                "Action": "CONVICTED",
-                "Description": "IMPROPER EQUIP - SPEEDOMETER",
-                "Severity": "INFRACTION",
-                "Law": "G.S. 20-123.2",
-                "Code": "4418"
+                "Records": [
+                    {
+                        "Action": "CHARGED",
+                        "Description": "SPEEDING(70 mph in a 50 mph zone)",
+                        "Severity": "TRAFFIC",
+                        "Law": "20-141(J1)"
+                    }
+                ],
+                "Disposed On": "2010-01-01",
+                "Disposition Method": "DISMISSAL WITHOUT LEAVE BY DA"
             }
         ],
-        "Disposed On": "2018-02-01",
-        "Disposition Method": "DISPOSED BY JUDGE"
+        "Superior Court Offense Information": [],
     }
-}
+]
 ```
 
 ## Local Setup
@@ -78,7 +68,7 @@ pip install -e .
 Read CIPRS PDF:
 
 ```
-python ciprs_reader.py ./cypress-example.pdf
+python ciprs_-eader.py ./cypress-example.pdf
 ```
 
 Run Jupyter:

--- a/ciprs-reader.py
+++ b/ciprs-reader.py
@@ -32,5 +32,5 @@ if __name__ == "__main__":
 
     logger.info("Running ciprs-reader on %s", args.input)
     reader = PDFToTextReader(args.input)
-    reader.parse(source=args.source)
+    reader.parse(save_source=args.source)
     print(reader.json())

--- a/ciprs_reader/__init__.py
+++ b/ciprs_reader/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "1.0.0"
+VERSION = "1.1.0"

--- a/ciprs_reader/reader/main.py
+++ b/ciprs_reader/reader/main.py
@@ -27,6 +27,7 @@ class PDFToTextReader:
         return json.dumps(self.records, indent=4, default=util.json_default)
 
 
+# pylint: disable=too-few-public-methods
 class SummaryRecordReader:
     """Read through Summary record and perform entity extraction using parsers."""
 

--- a/ciprs_reader/reader/util.py
+++ b/ciprs_reader/reader/util.py
@@ -1,4 +1,32 @@
-"""Utilities for PDFToTextReader"""
+import subprocess
+
+
+def convert_to_text(path):
+    """Convert PDF to text using pdftotext library."""
+    run = subprocess.run(
+        f"pdftotext -layout -enc UTF-8 {path} -",
+        check=True,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return run.stdout.decode("utf-8")
+
+
+def multi_summary_record_reader(path):
+    """
+    Sometimes multiple Summary CIPRS records are combined into a
+    single PDF for easier document management by the attorney. This
+    method splits records up for individual processing.
+    """
+    text = convert_to_text(path)
+    records = text.split("Case Summary for Court Case")
+    # trim any short records (probably just header text)
+    records = [x for x in records if len(x) > 1000]
+    # re-add text that was used to split to each record
+    records = ["Case Summary for Court Case" + x for x in records]
+    for record in records:
+        yield record
 
 
 def json_default(obj):
@@ -9,7 +37,7 @@ def json_default(obj):
         raise TypeError("{} can not be JSON encoded".format(type(obj)))
 
 
-class Reader:
+class LineReader:
     """Wrapper class to iterate over lines in a string."""
 
     def __init__(self, source):


### PR DESCRIPTION
Closes #33 

Sometimes multiple Summary CIPRS records are combined into a single PDF for easier document management by the attorney. This method splits records up for individual processing.

The JSON output will now always be a list of dicts, rather than just a dict. So dear-petition will be updated next.