### PR TITLE
County names with spaces are not parsed properly

### DIFF
--- a/ciprs_reader/parser/section/header.py
+++ b/ciprs_reader/parser/section/header.py
@@ -13,7 +13,7 @@ class CaseDetails(HeaderParser):
     """Extract County and File No from header on top of first page"""
 
     pattern = (
-        r"\s*Case (Details|Summary) for Court Case[\s:]+(?P<county>\w+) (?P<fileno>\w+)"
+        r"\s*Case (Details|Summary) for Court Case[\s:]+(?P<county>(\w\s*)+) (?P<fileno>\w+)"
     )
 
     def extract(self, matches, report):

--- a/tests/parsers/test_header.py
+++ b/tests/parsers/test_header.py
@@ -12,6 +12,14 @@ CASE_DETAIL_DATA = [
         {"county": "ORANGE", "fileno": "99FN9999999"},
         " Case Summary for Court Case: ORANGE 99FN9999999",
     ),
+    (
+        {"county": "NEW HANOVER", "fileno": "00GR000000"},
+        "  Case Details for Court Case NEW HANOVER 00GR000000  ",
+    ),
+    (
+        {"county": "OLD HANOVER", "fileno": "99FN9999999"},
+        " Case Summary for Court Case: OLD HANOVER 99FN9999999",
+    ),
 ]
 
 


### PR DESCRIPTION
Header parser now recognizes county names with spaces. Test cases added to confirm new behavior.

Fixes #37 