### PR TITLE
Accept special characters in county names

### DIFF
--- a/ciprs_reader/parser/section/header.py
+++ b/ciprs_reader/parser/section/header.py
@@ -13,7 +13,7 @@ class CaseDetails(HeaderParser):
     """Extract County and File No from header on top of first page"""
 
     pattern = (
-        r"\s*Case (Details|Summary) for Court Case[\s:]+(?P<county>(\w\s*)+) (?P<fileno>\w+)"
+        r"\s*Case (Details|Summary) for Court Case[\s:]+(?P<county>(\w\s*.*)+) (?P<fileno>\w+)"
     )
 
     def extract(self, matches, report):

--- a/tests/parsers/test_header.py
+++ b/tests/parsers/test_header.py
@@ -20,6 +20,10 @@ CASE_DETAIL_DATA = [
         {"county": "OLD HANOVER", "fileno": "99FN9999999"},
         " Case Summary for Court Case: OLD HANOVER 99FN9999999",
     ),
+    (
+        {"county": "GUILFORD-GR", "fileno": "15CR000000"},
+        " Case Summary for Court Case: GUILFORD-GR 15CR000000",
+    ),
 ]
 
 


### PR DESCRIPTION
Recognize county names with special chars in header parser. Test case added.
For issue https://github.com/deardurham/ciprs-reader/issues/43