### PR TITLE
Hopefully fix all future whitespace issues by introducing list regex pattern

### DIFF
--- a/ciprs_reader/parser/base.py
+++ b/ciprs_reader/parser/base.py
@@ -21,7 +21,13 @@ class Parser:
     is_line_parser = True
 
     def __init__(self, report, state):
-        self.re = re.compile(self.pattern)
+        if isinstance(self.pattern, list):
+            pattern = r"\s*".join(self.pattern)
+        elif isinstance(self.pattern, str):
+            pattern = self.pattern
+        else:
+            raise TypeError('Pattern must be string or array')
+        self.re = re.compile(pattern)
         self.report = report
         self.matches = None
         self.document = None

--- a/ciprs_reader/parser/lines.py
+++ b/ciprs_reader/parser/lines.py
@@ -10,10 +10,9 @@ logger = logging.getLogger(__name__)
 
 class DefendentDOB(Parser):
 
-    pattern = r"\s*Date of Birth/Estimated Age:[\sa-zA-Z]*(?P<value>[\d/]+)[ ]{2,}"
+    pattern = ["Date", 'of', 'Birth/Estimated', r"Age:[\sa-zA-Z]*(?P<value>[\d/]+)[ ]{2,}"]
     re_method = "search"
     section = ("Defendant", "Date of Birth/Estimated Age")
-    is_line_parser = False
 
     def clean(self, matches):
         """Parse and convert the date to ISO 8601 format"""

--- a/ciprs_reader/parser/section/case_information.py
+++ b/ciprs_reader/parser/section/case_information.py
@@ -13,13 +13,13 @@ class CaseInformationParser(Parser):
 
 class CaseStatus(CaseInformationParser):
 
-    pattern = r"\s*Case Status:\s*(?P<value>\w+)"
+    pattern = [r"\s*Case", "Status:", r"(?P<value>\w+)"]
     section = ("Case Information", "Case Status")
 
 
 class OffenseDate(CaseInformationParser):
 
-    pattern = r".*Offense Date:[\sa-zA-Z]*(?P<value>[\d/]+)[ ]{2,}"
+    pattern = [r"\s*Offense", r"Date:[\sa-zA-Z]*(?P<value>[\d/]+)[ ]{2,}"]
     section = ("Case Information", "Offense Date")
 
     def clean(self, matches):
@@ -31,7 +31,7 @@ class OffenseDate(CaseInformationParser):
 
 class OffenseDateTime(CaseInformationParser):
 
-    pattern = r".*Offense Date/Time:\s*(?P<value>[\w/ :]+[AaPp][Mm])"
+    pattern = [r"\s*Offense", r"Date/Time:\s*(?P<value>[\w/ :]+[AaPp][Mm])"]
     section = ("Case Information", "Offense Date")
 
     def clean(self, matches):
@@ -43,7 +43,8 @@ class OffenseDateTime(CaseInformationParser):
 
 class CaseWasServedOnDate(CaseInformationParser):
 
-    pattern = r".*Case Was Served on:\s*(?P<value>[\d/:]+)"
+    pattern = ["Case", "Was", "Served", r"on:\s*(?P<value>[\d/:]+)"]
+    re_method = "search"
     section = ("Case Information", "Arrest Date")
 
     def clean(self, matches):

--- a/ciprs_reader/parser/section/defendant.py
+++ b/ciprs_reader/parser/section/defendant.py
@@ -11,13 +11,13 @@ class DefendantParser(Parser):
 
 class DefendantRace(DefendantParser):
 
-    pattern = r"\s*Race: \s*(?P<value>\w+)"
+    pattern = [r"\s*Race:", r"(?P<value>\w+)"]
     section = ("Defendant", "Race")
 
 
 class DefendantSex(DefendantParser):
 
-    pattern = r"\s*Sex: \s*(?P<value>\w+)"
+    pattern = [r"\s*Sex:", r"(?P<value>\w+)"]
     section = ("Defendant", "Sex")
 
     def clean(self, matches):

--- a/ciprs_reader/parser/section/header.py
+++ b/ciprs_reader/parser/section/header.py
@@ -12,7 +12,8 @@ class HeaderParser(Parser):
 class CaseDetails(HeaderParser):
     """Extract County and File No from header on top of first page"""
 
-    pattern = r"\s*Case\s+(Details|Summary)\s+for\s+Court\s+Case[\s:]+(?P<county>.+)\s+(?P<fileno>\w+)"
+    pattern = ["Case", r"(Details|Summary)", "for", "Court", r"Case[\s:]+(?P<county>.+)\s+(?P<fileno>\w+)"]
+    re_method = "search"
 
     def extract(self, matches, report):
         report["General"]["County"] = matches["county"]
@@ -21,7 +22,7 @@ class CaseDetails(HeaderParser):
 
 class DefendantName(HeaderParser):
 
-    pattern = r"\s*Defendant: \s*(?P<value>\S+)"
+    pattern = [r"\s*Defendant:", r"(?P<value>\S+)"]
     section = ("Defendant", "Name")
 
     def clean(self, matches):

--- a/ciprs_reader/parser/state.py
+++ b/ciprs_reader/parser/state.py
@@ -33,7 +33,7 @@ class RecordSection(Parser):
 
 class CaseInformation(RecordSection):
 
-    pattern = r"^\s*Case Information\s*$"
+    pattern = [r"\s*Case", r"Information$"]
 
     def clean(self, matches):
         return Section.CASE_INFORMATION
@@ -41,7 +41,7 @@ class CaseInformation(RecordSection):
 
 class DefendantSection(RecordSection):
 
-    pattern = r"^\s*Defendant\s*$"
+    pattern = r"\s*Defendant$"
 
     def clean(self, matches):
         return Section.DEFENDANT
@@ -49,7 +49,7 @@ class DefendantSection(RecordSection):
 
 class DistrictCourtOffenseSection(RecordSection):
 
-    pattern = r"^\s*District\s+Court\s+Offense\s+Information\s*$"
+    pattern = [r"\s*District", "Court", "Offense", r"Information$"]
 
     def clean(self, matches):
         return Section.DISTRICT_OFFENSE
@@ -57,7 +57,7 @@ class DistrictCourtOffenseSection(RecordSection):
 
 class SuperiorCourtOffenseSection(RecordSection):
 
-    pattern = r"^\s*Superior\s+Court\s+Offense\s+Information\s*$"
+    pattern = [r"\s*Superior", "Court", "Offense", r"Information$"]
 
     def clean(self, matches):
         return Section.SUPERIOR_OFFENSE

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -17,11 +17,11 @@ def test_pdftotext_args_v1(mock_subprocess):
     cmd = mock_subprocess.call_args[0][0]
     assert "-layout" in cmd
     assert "pdftotext" in cmd
-    assert "pdftotext-4.03" not in cmd
+    assert "pdftotext-4" not in cmd
 
 
 def test_pdftotext_args_v2(mock_subprocess):
     PDFToTextReader("dummy.pdf", mode=ParserMode.V2).parse()
     cmd = mock_subprocess.call_args[0][0]
     assert "-table" in cmd
-    assert "pdftotext-4.03" in cmd
+    assert "pdftotext-4" in cmd


### PR DESCRIPTION
When you specify an list as the parser's regex pattern, we now automatically append `\s*` between the items of the list. This should handle all cases of the new parser mode breaking the parsers by inserting unexpected amounts of whitespace into the extracted pdf text