### PR TITLE
Fix court RecordSection parser

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,7 @@
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=missing-docstring,invalid-name,no-self-use,bare-except
+disable=missing-docstring,invalid-name,bare-except
 
 [DESIGN]
 max-parents=13

--- a/ciprs_reader/parser/state.py
+++ b/ciprs_reader/parser/state.py
@@ -22,7 +22,10 @@ class RecordSection(Parser):
     def match(self, document):
         self.matches = None
         self.document = document
-        matches = self.re.match(str(document))
+        if self.re_method == "match":
+            matches = self.re.match(str(document))
+        else:
+            matches = self.re.search(str(document))
         if matches:
             self.matches = self.clean(matches)
         return self.matches
@@ -49,6 +52,7 @@ class DefendantSection(RecordSection):
 
 class DistrictCourtOffenseSection(RecordSection):
 
+    re_method = "search"
     pattern = [r"\s*District", "Court", "Offense", r"Information$"]
 
     def clean(self, matches):
@@ -57,6 +61,7 @@ class DistrictCourtOffenseSection(RecordSection):
 
 class SuperiorCourtOffenseSection(RecordSection):
 
+    re_method = "search"
     pattern = [r"\s*Superior", "Court", "Offense", r"Information$"]
 
     def clean(self, matches):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest==7.1.2
 pytest-cov==2.11.1
-pytest-pylint==0.18.0
+pytest-pylint==0.20.0
 pre-commit==2.11.1

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,4 +1,6 @@
-from ciprs_reader.parser import lines as parsers
+import pytest
+
+from ciprs_reader.parser import lines as parsers, state as state_parsers
 
 
 def test_defendent_dob(report, state):
@@ -42,3 +44,19 @@ def test_court_type_crs(report, state):
     assert parser.matches is not None, "Regex match failed"
     assert parser.matches == {"Superior": "Yes"}
     assert report["General"]["Superior"] == "Yes"
+
+@pytest.mark.parametrize(
+    "document,parser",
+    [
+        (
+            "Not a certified copy. ~Not a certified copy. ~  District Court    Offense Information",
+            state_parsers.DistrictCourtOffenseSection,
+        ),
+        (
+            "Not a certified copy. ~Not a certified copy. ~  Superior    Court Offense    Information",
+            state_parsers.SuperiorCourtOffenseSection,
+        )
+    ],
+)
+def test_offense_parsers__search_section(document, parser, report, state):
+    assert parser(report, state).match(document) is not None


### PR DESCRIPTION
We may want to migrate more parsers to using `search` instead of `match` since CIPRS pdfs love to insert junk at the start of lines.